### PR TITLE
Change workflow to use makefile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,16 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Archive Release
-      uses: thedoctor0/zip-release@master
-      with:
-        filename: 'LiveTL.zip'
-        path: "LiveTL"
-    - name: Upload binaries to release
+    - name: Package extensions
+      run: make
+    - name: Upload Chrome package to release
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: LiveTL.zip
-        asset_name: LiveTL.zip
+        file: dist/chrome/LiveTL.zip
+        asset_name: LiveTL-Chrome.zip
+        tag: ${{ github.ref }}
+        overwrite: true
+    - name: Upload Firefox package to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: dist/firefox/LiveTL.zip
+        asset_name: LiveTL-Firefox.zip
         tag: ${{ github.ref }}
         overwrite: true


### PR DESCRIPTION
This uses make in the workflow to package the extension. Uploaded zips are also LiveTL-Chrome.zip and LiveTL-Firefox.zip.