### PR TITLE
Improved chat message parsing

### DIFF
--- a/LiveTL/js/lib/filter.js
+++ b/LiveTL/js/lib/filter.js
@@ -47,3 +47,5 @@ function isLangMatch (textLang, currentLang) {
     currentLang.lang.toLowerCase().startsWith(s)
   ))
 }
+
+module.exports = { parseTranslation, isLangMatch };


### PR DESCRIPTION
Improves parse speed (some benchmarks down below). Times shown below are times taken to run benchmark code.

Translation messages - with [lang] block (minority of messages):

- old: ~2.2s
- new: ~100ms

All other messages - without [lang] block (majority of messages - should make a difference here):

- old: ~2.2s
- new: ~200ms

Test code:

```js
// tested on node 14
// some random discord message
const testTrans = "[en] thats why i told you to look into it and was surprised you were continuing on without even checking it xddd";

const messagesPerRun = 1000000;

console.time("label");

for (let i = 0; i < messagesPerRun; i++) {
  parseFunction(testTrans);
}

console.timeEnd("label");
```

Seems to work on both firefox and edge. Not familiar with all the ways translators tag their messages so if i missed anything, lemme know.