### PR TITLE
Implemented delayed messages for replays

### DIFF
--- a/LiveTL/js/frame.js
+++ b/LiveTL/js/frame.js
@@ -133,10 +133,6 @@ async function runLiveTL() {
       await setStorage('displayModMessages', true);
     }
 
-    /********************************************
-     * TODO FIXME Messages need to be displayed at the appropriate time in the video, not whenever we receive them.
-     ********************************************/
-
     // Check to see if the sender is a mod, and we display mod messages
     if (messageInfo.author.types.includes(authorType.MOD) && displayModMessages) {
       // If the mod isn't in the sender list, add them
@@ -463,7 +459,6 @@ async function loaded() {
           let chunk = {
             type: 'messageChunk',
             messages: messages,
-            videoTimestamp: mostRecentTimestamp,
             video: getV(window.location.href) || getV(window.parent.location.href)
           };
           console.debug('Sending chunk', chunk);

--- a/LiveTL/js/index.js
+++ b/LiveTL/js/index.js
@@ -34,13 +34,80 @@ let c = params.continuation;
 let r = params.isReplay;
 r = r == null ? c : r;
 
+let progress = {
+  current: null,
+  previous: null
+};
+
+let queued = new class QueuedMessages {
+  next = null
+  messages = {}
+  push (message, secs) {
+    if (!this.next) this.next = secs;
+    if (!this.messages[secs]) this.messages[secs] = [];
+    this.messages[secs].push(message);
+  }
+  pop (secs) {
+    if (!this.next || secs < this.next) return false;
+    let m = [...this.messages[this.next]];
+    delete this.messages[this.next];
+    this.next = Object.keys(this.messages)[0]; // Assume order
+    return m;
+  }
+  clear () {
+    this.messages = {};
+    this.next = null;
+  }
+}
+
 window.addEventListener('message', d => {
   d = JSON.parse(JSON.stringify(d.data));
 
   try {
     chat.contentWindow.postMessage(d, '*');
+  } catch {}
+
+  if (params.isReplay) {
+    // Enable queued message transfer
+    // Dont block
+    setTimeout(() => {
+      if (d['yt-player-video-progress']) {
+        progress.current = d['yt-player-video-progress'];
+        if (!progress.previous) progress.previous = progress.current;
+        if (Math.abs(progress.previous - progress.current) > 1) {
+          // Difference in progress above a second, assume user scrubbed, clear.
+          queued.clear();
+        }
+        // Find queued messages for current timeframe
+        let m = queued.pop(progress.current);
+        if (m) {
+          ltlchat.contentWindow.postMessage({
+            type: 'messageChunk',
+            messages: m,
+            video: v
+          }, '*');
+        }
+        progress.previous = progress.current;
+      } else if (d.type === 'messageChunk') {
+        d.messages = d.messages.filter(message => {
+          let secs = Array.from(message.timestamp.split(':'), t => parseInt(t)).reverse();
+          secs = secs[0] + (secs[1] ? secs[1] * 60 : 0)
+                         + (secs[2] ? secs[2] * 60*60 : 0);
+
+          let diff = progress.current - secs;
+          if (diff < 0) { // Message from the future ✨🔮, queue
+            queued.push(message, secs);
+            return false; // Remove from original event
+          } else return true;
+        });
+
+        // Send past and current messages
+        ltlchat.contentWindow.postMessage(d, '*');
+      }
+    }, 0);
+  } else {
     ltlchat.contentWindow.postMessage(d, '*');
-  } catch (e) { }
+  }
 });
 
 let q = `?isReplay=${(r ? 1 : '')}&v=${v}${(c ? `&continuation=${c}` : '')}`;


### PR DESCRIPTION
This pull requests implements queued delayed message transfer for incoming messages in the future of current time of video.

This means replays will have accurate delivery of messages according to the video timeline.

Fixes #92 