### PR TITLE
View In LTL button doesn't appear in safari on archives anymore

### DIFF
--- a/LiveTL/js/frame.js
+++ b/LiveTL/js/frame.js
@@ -326,8 +326,13 @@ async function insertLiveTLButtons(isHolotools = false) {
     redirectTab(`${await getWAR('index.html')}?v=${params.v}${restOfURL()}`);
   };
 
+  var isReplay = hasReplayChatOpen()
+
   if (!isHolotools) {
-    makeButton('Watch in LiveTL', window.watchInLiveTL);
+    if (!(isSafari && isReplay)){
+      //Archives don't work in ltl view on safari
+      makeButton('Watch in LiveTL', window.watchInLiveTL);
+    }
 
     makeButton('Pop Out Translations',
       async () => {


### PR DESCRIPTION
Archives do not work in safari in LTL view, so I'm disabling the button